### PR TITLE
Replaced usage of Timeout::timeout

### DIFF
--- a/lib/culerity/remote_browser_proxy.rb
+++ b/lib/culerity/remote_browser_proxy.rb
@@ -13,13 +13,15 @@ module Culerity
     # +time_to_wait+ is 30 seconds by default
     # 
     # Returns true upon success
-    # Raises Timeout::Error when +time_to_wait+ is reached.
+    # Raises RuntimeError when +time_to_wait+ is reached.
     # 
     def wait_until time_to_wait=30, &block
-      Timeout.timeout(time_to_wait) do
-        until block.call
-          sleep 0.1
+      time_limit = Time.now + time_to_wait
+      until block.call 
+        if Time.now > time_limit
+          raise "wait_until timeout after #{time_to_wait} seconds"
         end
+        sleep 0.1
       end
       true
     end
@@ -29,13 +31,15 @@ module Culerity
     # +time_to_wait+ is 30 seconds by default
     # 
     # Returns true upon success
-    # Raises Timeout::Error when +time_to_wait+ is reached.
+    # Raises RuntimeError when +time_to_wait+ is reached.
     # 
     def wait_while time_to_wait=30, &block
-      Timeout.timeout(time_to_wait) do
-        while block.call
-          sleep 0.1
+      time_limit = Time.now + time_to_wait
+      while block.call
+        if Time.now > time_limit
+          raise "wait_while timeout after #{time_to_wait} seconds"
         end
+        sleep 0.1
       end
       true
     end

--- a/spec/remote_browser_proxy_spec.rb
+++ b/spec/remote_browser_proxy_spec.rb
@@ -28,7 +28,7 @@ describe Culerity::RemoteBrowserProxy do
     proxy = Culerity::RemoteBrowserProxy.new @io
     lambda {
       proxy.wait_until(0.1) { false }
-    }.should raise_error(Timeout::Error)
+    }.should raise_error(RuntimeError)
   end
   
   it "should return successfully when wait_until returns true" do
@@ -40,7 +40,7 @@ describe Culerity::RemoteBrowserProxy do
     proxy = Culerity::RemoteBrowserProxy.new @io
     lambda {
       proxy.wait_while(0.1) { true }
-    }.should raise_error(Timeout::Error)
+    }.should raise_error(RuntimeError)
   end
   
   it "should return successfully when wait_while returns !true" do


### PR DESCRIPTION
As requested I forked the project and here is the pull request. I am repeating my original note to you, updated at the end with further explanation about why this code will behave differently than the current code.

While running large set of cucumber features I would occasionally run into a situation where a scenario would fail due to a timeout (browser.wait_until was being called) and every single test that followed would fail as well.

It turned out that the timeout was expiring after the culerity client had sent a request to the jruby server, but before it had read the response off of the pipe. From that point forward every time a new request was sent it would immediately read the response from the previous request, which never worked out very well.

Here is a patch that prevents this from happening by replacing the usage of Timeout::timeout with a simple loop that just checks the current time against the time when the method was first called. It might not be quite as exact as the Timeout::timeout, but it won't corrupt the pipe when it fails either.

The reason Timeout::timeout is so unsafe is because of how it works. When used it spawns a thread that sleeps for the specified number of seconds. When it wakes up, if the code executing within the Timeout has not yet completed, it immediately raises a Timeout::Error on the original thread. You have no control over where in the code the exception will be raised - it just happens after so many seconds. In the case of culerity, it is possible for the Timeout::Error to be raised after a request has been sent from the client to the server, but before the response has been read from the pipe.

My patch fixes this by doing a check _after_ the predicate block has been executed, and then raising an exception (I just went with a RuntimeError because unlike a Timeout::Error it will be caught by a begin/rescue without having to specify the type of exception to catch). 

In summary, a Timeout::timeout might raise an exception anywhere during the executing of the predicate block, including during client/server communication. This new code raises an exception at a known point in time, never during client/server communication.

Thanks,
Patrick
