### PR TITLE
Improve error messages

### DIFF
--- a/lib/culerity/remote_object_proxy.rb
+++ b/lib/culerity/remote_object_proxy.rb
@@ -20,7 +20,11 @@ module Culerity
     def id
       send_remote(:id)
     end
-
+    
+    def inspect
+      send_remote(:inspect)
+    end
+    
     def method_missing(name, *args, &block)
       send_remote(name, *args, &block)
     end

--- a/lib/culerity/remote_object_proxy.rb
+++ b/lib/culerity/remote_object_proxy.rb
@@ -55,7 +55,11 @@ module Culerity
       if res.first == :return
         res[1]
       elsif res.first == :exception
-        raise CulerityException.new("#{res[1]}: #{res[2]}", res[3])
+        begin
+          raise "local trace"
+        rescue => ex
+          raise CulerityException.new("#{res[1]}: #{res[2]}", res[3] + ex.backtrace)
+        end
       end
     end
 

--- a/spec/celerity_server_spec.rb
+++ b/spec/celerity_server_spec.rb
@@ -133,4 +133,16 @@ describe Culerity::CelerityServer do
     _out.should_receive(:<<).with(/^\[:exception, \"RuntimeError\", \"test exception with \\\"quotes\\\"\", \[.*\]\]\n$/)
     Culerity::CelerityServer.new(_in, _out)
   end
+  
+  it "should extract a js stack trace if available and prepend it on the regular backtrace" do
+    exception = RuntimeError.new("the exception")
+    exception.stub!(:cause => stub('ex2', :cause => stub('ex3', :getScriptStackTrace => "The\nStack\nTrace")))
+    
+    @browser.stub!(:goto).and_raise(exception)
+    _in = stub 'in'
+    _in.stub!(:gets).and_return("[[\"browser0\", \"goto\", \"/homepage\"]]\n", "[\"_exit_\"]\n")
+    _out = stub 'out'
+    _out.should_receive(:<<).with(/^\[:exception, \"RuntimeError\", \"the exception\", \[\"The\", \"Stack\", \"Trace\", \".*\"\]\]\n$/)
+    Culerity::CelerityServer.new(_in, _out)
+  end
 end

--- a/spec/remote_object_proxy_spec.rb
+++ b/spec/remote_object_proxy_spec.rb
@@ -79,6 +79,20 @@ describe Culerity::RemoteObjectProxy do
     }.should raise_error(Culerity::CulerityException)
   end
   
+  it "should include the full 'local' back trace in addition to the 'remote' backtrace" do
+    io = stub 'io', :gets => %Q{[:exception, "RuntimeError", "test exception", ["Remote", "Backtrace"]]}, :<< => nil
+    proxy = Culerity::RemoteObjectProxy.new 345, io
+    begin
+      proxy.goto '/home'
+    rescue => ex
+      puts ex.backtrace
+      ex.backtrace[0].should == "Remote"
+      ex.backtrace[1].should == "Backtrace"
+      ex.backtrace.detect {|line| line =~ /lib\/culerity\/remote_object_proxy\.rb/}.should_not be_nil
+      ex.backtrace.detect {|line| line =~ /spec\/remote_object_proxy_spec\.rb/}.should_not be_nil
+    end
+  end
+  
   it "should send exit" do
     io = stub 'io', :gets => '[:return]'
     io.should_receive(:<<).with('["_exit_"]')

--- a/spec/remote_object_proxy_spec.rb
+++ b/spec/remote_object_proxy_spec.rb
@@ -41,6 +41,13 @@ describe Culerity::RemoteObjectProxy do
     proxy = Culerity::RemoteObjectProxy.new 345, io
     proxy.goto '/homepage'
   end
+
+  it "should send inspect as a serialized method call to the output" do
+    io = stub 'io', :gets => '[:return, "inspect output"]'
+    io.should_receive(:<<).with(%Q{[[345, "inspect"]]\n})
+    proxy = Culerity::RemoteObjectProxy.new 345, io
+    proxy.inspect.should == "inspect output"
+  end
   
   it "should send the serialized method call with a proc argument to the output" do
     io = stub 'io', :gets => "[:return]"
@@ -57,7 +64,7 @@ describe Culerity::RemoteObjectProxy do
     
     proxy.send_remote(:method) { "lambda { true }" }
   end
-  
+    
   it "should return the deserialized return value" do
     io = stub 'io', :gets => "[:return, :okay]\n", :<< => nil
     proxy = Culerity::RemoteObjectProxy.new 345, io


### PR DESCRIPTION
These changes are all aimed at providing more informative errors when a cucumber step fails.
1. inspect was added to RemoteObjectProxy so it will forward to the proxied celerity object.
2. Check exceptions sent back from the celerity server to see if they contain a javascript stack trace, and if so prepend that stack trace.
3. When an exception is sent back from the celerity server append the "local" backtrace to the exception so a user can see the full stack trace in the cucumber steps (not just the line in the .feature file which cucumber provides) as well as the stack trace from the celerity server.
