### PR TITLE
Problems with culerity when bundler is managing app dependencies

### DIFF
--- a/lib/culerity.rb
+++ b/lib/culerity.rb
@@ -41,8 +41,7 @@ module Culerity
   end
   
   def self.run_server
-    ENV['RUBYOPT'] = ''
-    IO.popen(%{#{jruby_invocation} "#{celerity_invocation}"}, 'r+').extend(ServerCommands)
+    IO.popen(%{RUBYOPT="" #{jruby_invocation} "#{celerity_invocation}"}, 'r+').extend(ServerCommands)
   end
   
   def self.run_rails(options = {})

--- a/lib/culerity.rb
+++ b/lib/culerity.rb
@@ -41,6 +41,7 @@ module Culerity
   end
   
   def self.run_server
+    ENV['RUBYOPT'] = ''
     IO.popen(%{#{jruby_invocation} "#{celerity_invocation}"}, 'r+').extend(ServerCommands)
   end
   

--- a/lib/start_celerity.rb
+++ b/lib/start_celerity.rb
@@ -1,3 +1,3 @@
 require 'rubygems'
-require 'culerity/celerity_server'
+require File.dirname(__FILE__) + '/culerity/celerity_server'
 Culerity::CelerityServer.new(STDIN, STDOUT)

--- a/spec/culerity_spec.rb
+++ b/spec/culerity_spec.rb
@@ -108,5 +108,14 @@ describe Culerity do
       Culerity.jruby_invocation = "rvm jruby@culerity ruby"
       Culerity.run_server
     end
+
+    it "should empty the RUBYOPT environment variable" do
+      Culerity.stub!(:celerity_invocation).and_return('/path/to/start_celerity.rb')
+      
+      ENV['RUBYOPT'] = "-I/usr/local/lib/ruby/gems/1.8/gems/bundler-1.0.7/lib -rbundler/setup"
+      Culerity.run_server
+
+      ENV['RUBYOPT'].should eql ""
+    end
   end
 end

--- a/spec/culerity_spec.rb
+++ b/spec/culerity_spec.rb
@@ -95,7 +95,7 @@ describe Culerity do
     it "shells out and sparks up jruby with the correct invocation" do
       Culerity.stub!(:celerity_invocation).and_return('/path/to/start_celerity.rb')
       
-      IO.should_receive(:popen).with('jruby "/path/to/start_celerity.rb"', 'r+')
+      IO.should_receive(:popen).with('RUBYOPT="" jruby "/path/to/start_celerity.rb"', 'r+')
       
       Culerity.run_server
     end
@@ -103,19 +103,10 @@ describe Culerity do
     it "allows a more complex situation, e.g. using RVM + named gemset" do
       Culerity.stub!(:celerity_invocation).and_return('/path/to/start_celerity.rb')
       
-      IO.should_receive(:popen).with('rvm jruby@culerity ruby "/path/to/start_celerity.rb"', 'r+')
+      IO.should_receive(:popen).with('RUBYOPT="" rvm jruby@culerity ruby "/path/to/start_celerity.rb"', 'r+')
       
       Culerity.jruby_invocation = "rvm jruby@culerity ruby"
       Culerity.run_server
-    end
-
-    it "should empty the RUBYOPT environment variable" do
-      Culerity.stub!(:celerity_invocation).and_return('/path/to/start_celerity.rb')
-      
-      ENV['RUBYOPT'] = "-I/usr/local/lib/ruby/gems/1.8/gems/bundler-1.0.7/lib -rbundler/setup"
-      Culerity.run_server
-
-      ENV['RUBYOPT'].should eql ""
     end
   end
 end


### PR DESCRIPTION
Hi Alex,

I have encountered a weird culerity behaviour when the gem dependencies of an app are managed by bundler.

When culerity invokes subprocess "jruby .../lib/start_celerity.rb", jruby reads the RUBYOPT env variable.

If bundler is involved it sets this variable to "-I/usr/local/lib/ruby/gems/1.8/gems/bundler-1.0.7/lib -rbundler/setup"
and this makes jruby ask for bundler gem.

The problem is discussed here: 
http://stackoverflow.com/questions/3445002/error-errnoepipe-broken-pipe-with-culerity/4538363%234538363

I have also figured out that "jruby .../lib/start_celerity.rb" doesn't really work on it's own (at least for me).
It should require "culerity/celerity_server" as a file and not a gem (as in bin/run_celerity_server.rb)
